### PR TITLE
Fix a really stupid "bug" that always crashes the game

### DIFF
--- a/common/src/main/kotlin/com/skyternity/deserted/PlatformInterface.kt
+++ b/common/src/main/kotlin/com/skyternity/deserted/PlatformInterface.kt
@@ -6,4 +6,3 @@ import net.minecraft.item.ItemGroup
 
 @ExpectPlatform
 fun printHelloWorld(): Unit = throw AssertionError()
-fun getItemGroup(): ItemGroup = throw AssertionError()

--- a/common/src/main/kotlin/com/skyternity/deserted/items/ItemRegistry.kt
+++ b/common/src/main/kotlin/com/skyternity/deserted/items/ItemRegistry.kt
@@ -12,7 +12,6 @@ import net.minecraft.item.ItemGroup
 @SuppressWarnings("unused")
 object ItemRegistry: ItemRegistryHelper(Deserted.MOD_ID) {
     val REGISTRY = DeferredRegister.create(Deserted.MOD_ID, Registry.ITEM_KEY)
-    val GROUP = getItemGroup();
 
     override fun defaultSettings(): Item.Settings = Item.Settings().group(ItemGroup.MISC)
 


### PR DESCRIPTION
use `CreativeTabs.create` if you need a custom item group/creative tab in the future